### PR TITLE
rework retrying implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,29 @@
 
 ## [Unreleased]
 
-- [BREAKING]: Stop re-export helper utilities from `retry` crate. If user
-  need them please use `retry` crate directly.
+### Removed
+
+- [BREAKING]: Remove `ThrottlePool::run()` & `ThrottlePool::run_retry()`.
+    - Use `pool.get(id).run(...)` as replacement.
+- [BREAKING]: Remove `ThrottleBuilder::fuzzy_fn()` & `ThrottlePoolBuilder::fuzzy_fn()`.
+    - Use `interval_fn(|| ...)` as replacement.
+- [BREAKING]: Remove optional features `retrying` & `fuzzy_fn` due to no longer needed.
+- [BREAKING]: Stop re-export helper utilities from `retry` crate.
+
+### Added
+
+- New method `ThrottlePool::get()` to access onderlaying `Throttle` instance.
+- New methods `ThrottleBuilder::interval_fn()` & `ThrottlePoolBuilder::interval_fn()` API accept
+  an user's algorithm to generate dynamic intervals.
+- New method `Throttle::run_failable()` allow throttle detect operation failed
+  and may change future interval calculation by `interval_fn()`.
+    - This error detecting logic also apply to new method `Throttle::retry()`.
+
+### Changed
+
+- [BREAKING]: New `Throttle::retry()` API replace old `Throttle::run_retry()`.
+    - Compare with old version, new API shared delay intervals with all operations
+      in current throttle scope.
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,6 @@ repository = "https://github.com/visig9/slottle"
 
 [dependencies]
 std-semaphore = "0.1.0"
-retry = { version = "1.1.0", optional = true }
-rand = { version = "0.7.3", optional = true }
 
 [dev-dependencies]
 rayon = "1.5.0"
-
-[features]
-default = []
-retrying = ["retry"]
-fuzzy_fns = ["rand"]
-
-[package.metadata.docs.rs]
-all-features = true

--- a/README.md
+++ b/README.md
@@ -1,105 +1,21 @@
 # slottle
 
-A simple Rust library provide thread-based throttle pool. It can dynamic create multiple throttles by user given resource id.
+A simple Rust crate provide thread-based throttle pool. It can dynamic create multiple throttles by user given resource id.
 
 For example, a web scraping tool may treat domain name as resource id to control access speed of each hosts in generic way. User can create multiple pools at the same time, each one have different configurations for different situations.
 
 
 
-## Example
+# Features
 
-````rust
-//! ```cargo
-//! [dependencies]
-//! rayon = "1.5.0"
-//! slottle = "0.2.0"
-//! ```
+- Not just individual throttle but also provide pool. (You can skip the pool if don't need it)
+- Both concurrent & delay interval are configurable.
+- Allow user defined algorithm to generate delay interval dynamically.
+- Failure sensitive & builtin retry support.
+- Easy to use.
+- Exhaustive document.
 
-use rayon::prelude::*;
-use slottle::ThrottlePool;
-use std::time::{Duration, Instant};
-
-fn main() {
-    // Make sure we have enough of threads can be blocked.
-    // Here we use rayon as example but you can choice any thread implementation.
-    rayon::ThreadPoolBuilder::new()
-        .num_threads(8)
-        .build_global()
-        .unwrap();
-
-    // Create ThrottlePool.
-    //
-    // In here `id` is `bool` type for demonstration.
-    // If you're writing a web spider, type of `id` might should be `url::Host`.
-    let throttles: ThrottlePool<bool> = ThrottlePool::builder()
-        .interval(Duration::from_millis(10)) // set interval to 10ms
-        .concurrent(2) // set concurrent to 2
-        .build()
-        .unwrap();
-
-    // HINT: according previous config, expected access speed is
-    // 2 per 10ms = 1 per 5ms (in each throttle)
-
-    let started_time = Instant::now();
-
-    let mut time_passed_ms_vec: Vec<f64> = vec![1, 2, 3, 4, 5, 6]
-        .into_par_iter()
-        .map(|x| {
-            throttles.run(
-                x >= 5, // 5,6 in throttle `true` & 1,2,3,4 in throttle `false`
-                // here is the operation we want to throttling
-                || {
-                    let time_passed_ms = started_time.elapsed().as_secs_f64() * 1000.0;
-                    println!(
-                        "[throttle: {:>5}] allowed job {} to start at: {:.2}ms",
-                        x >= 5, x, time_passed_ms,
-                    );
-
-                    // // you can also add some long-running task to see how throttle work
-                    // std::thread::sleep(Duration::from_millis(20));
-
-                    time_passed_ms
-                },
-            )
-        })
-        .collect();
-
-    // Verify all time_passed_ms as we expected...
-
-    time_passed_ms_vec.sort_by(|a, b| a.partial_cmp(b).unwrap());
-
-    let expected_time_passed_ms = [0.0, 0.0, 5.0, 5.0, 10.0, 15.0];
-    time_passed_ms_vec
-        .into_iter()
-        .zip(expected_time_passed_ms.iter())
-        .for_each(|(value, expected)| {
-            assert_eq_approx("time_passed (ms)", value, *expected, 1.0)
-        });
-}
-
-/// assert value approximate equal to expected value.
-fn assert_eq_approx(name: &str, value: f64, expected: f64, espilon: f64) {
-    let expected_range = (expected - espilon)..(expected + espilon);
-    assert!(
-        expected_range.contains(&value),
-        "{}: {} out of accpetable range: {:?}",
-        name, value, expected_range,
-    );
-}
-````
-
-Output:
-
-```
-[throttle: false] allowed job 1 to start at: 0.05ms
-[throttle:  true] allowed job 5 to start at: 0.06ms
-[throttle: false] allowed job 2 to start at: 5.10ms
-[throttle:  true] allowed job 6 to start at: 5.12ms
-[throttle: false] allowed job 3 to start at: 10.11ms
-[throttle: false] allowed job 4 to start at: 15.11ms
-```
-
-Please check online documents for more detail.
+Check [online document](https://docs.rs/slottle/) for more detail.
 
 
 


### PR DESCRIPTION
Basically, this commit move "how long should delay if run failed" logic
into a Throttle scope, rather than let it associate with single
retrying sequence (like what original run_retry() do). That because the
same Throttle should mapping to the same quota slot in theory. Retrying
single operation should not own it individual delay algorithm.

The concept change also effect many things:

- An API to setup algorithm of interval in Throttle scope.
- A data collecting system to collect data and feed it to
  interval calculation algorithm.
- An API to run operation which not-need-to-retry but failable.

This is a big change with a lot of breaking change. Check CHANGELOG.md
too found them all.